### PR TITLE
Path transformers

### DIFF
--- a/buildfox.py
+++ b/buildfox.py
@@ -52,6 +52,13 @@ filter toolset:msvc
 	auto r"(?i).*\.dll": link_dll r"(?i).*\.(obj|lib)$"
 	auto r"(?i).*\.lib": lib r"(?i).*\.(obj|lib)$"
 
+	# extensions transformers
+	transformer app: ${param}.exe
+	transformer obj: ${param}.obj
+	transformer lib: ${param}.lib
+	# dll is not included because shared libs have different logical behavior on different platforms
+	# TODO fix dll support ?
+
 	# MSVC flags
 	# more info here https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
 

--- a/examples/console_app/includepath/build.fox
+++ b/examples/console_app/includepath/build.fox
@@ -5,5 +5,5 @@ out = build/bin_${variation}
 includedirs = test1 test2
 
 # build all
-build $out/*.obj: auto *.cpp test1/*.c test2/*.cpp
-build $out/app.exe: auto $out/*.obj
+build $out/obj(*): auto *.cpp test1/*.c test2/*.cpp
+build $out/app(app): auto $out/obj(*)

--- a/examples/console_app/simple/build.fox
+++ b/examples/console_app/simple/build.fox
@@ -1,5 +1,5 @@
 filter variation:release
 	defines = RELEASE
 
-build *.obj: auto *.cpp *.c
-build app.exe: auto *.obj
+build obj(*): auto *.cpp *.c
+build app(test): auto obj(*)

--- a/examples/shared_lib/simple/build.fox
+++ b/examples/shared_lib/simple/build.fox
@@ -1,4 +1,7 @@
 defines = DLL_EXPORT
 
-build *.obj: auto *.cpp
-build app.dll | app.lib: auto *.obj
+build obj(*): auto *.cpp
+
+# TODO
+filter toolset:msvc
+	build app.dll | lib(app): auto obj(*)

--- a/examples/shared_lib/withapp/build.fox
+++ b/examples/shared_lib/withapp/build.fox
@@ -8,13 +8,13 @@ includedirs = test1 test2
 
 defines = TEST
 
-build $out/test1/*.obj: auto test1/*.cpp
+build $out/test1/obj(*): auto test1/*.cpp
 	defines += DLL_EXPORT
-build $out/test1.dll | $out/test1.lib: auto $out/test1/*.obj
+build $out/test1.dll | $out/lib(test1): auto $out/test1/obj(*)
 
-build $out/test2/*.obj: auto test2/*.cpp
+build $out/test2/obj(*): auto test2/*.cpp
 	defines += DLL_EXPORT2
-build $out/test2.dll | $out/test2.lib: auto $out/test2/*.obj
+build $out/test2.dll | $out/lib(test2): auto $out/test2/obj(*)
 
-build $out/*.obj: auto *.cpp
-build $out/app.exe: auto $out/*.obj $out/*.lib
+build $out/obj(*): auto *.cpp
+build $out/app(app): auto $out/obj(*) $out/lib(*)

--- a/examples/static_lib/simple/build.fox
+++ b/examples/static_lib/simple/build.fox
@@ -1,2 +1,2 @@
-build *.obj: auto *.c
-build app.lib: auto *.obj
+build obj(*): auto *.c
+build lib(app): auto obj(*)

--- a/examples/static_lib/withapp/build.fox
+++ b/examples/static_lib/withapp/build.fox
@@ -6,11 +6,11 @@ includedirs = test1 test2
 
 # build all
 
-build $out/test1/*.obj: auto test1/*.c
-build $out/test1.lib: auto $out/test1/*.obj
+build $out/test1/obj(*): auto test1/*.c
+build $out/lib(test1): auto $out/test1/obj(*)
 
-build $out/test2/*.obj: auto test2/*.cpp
-build $out/test2.lib: auto $out/test2/*.obj
+build $out/test2/obj(*): auto test2/*.cpp
+build $out/lib(test2): auto $out/test2/obj(*)
 
-build $out/*.obj: auto *.cpp
-build $out/app.exe: auto $out/*.obj $out/*.lib
+build $out/obj(*): auto *.cpp
+build $out/app(app): auto $out/obj(*) $out/lib(*)


### PR DESCRIPTION
Fixes #18 

In general I feel ok-ish about this one. It adds one more escape sequence though.
For example `obj((*$))`. But this escape sequence only works inside transformer group and will not work anywhere else.
