### PR TITLE
shared lib transformer

### DIFF
--- a/buildfox.py
+++ b/buildfox.py
@@ -56,8 +56,7 @@ filter toolset:msvc
 	transformer app: ${param}.exe
 	transformer obj: ${param}.obj
 	transformer lib: ${param}.lib
-	# dll is not included because shared libs have different logical behavior on different platforms
-	# TODO fix dll support ?
+	transformer shlib: ${param}.dll
 
 	# MSVC flags
 	# more info here https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx

--- a/examples/shared_lib/simple/build.fox
+++ b/examples/shared_lib/simple/build.fox
@@ -1,7 +1,4 @@
 defines = DLL_EXPORT
 
 build obj(*): auto *.cpp
-
-# TODO
-filter toolset:msvc
-	build app.dll | lib(app): auto obj(*)
+build shlib(app) | lib(app): auto obj(*)

--- a/examples/shared_lib/withapp/build.fox
+++ b/examples/shared_lib/withapp/build.fox
@@ -1,20 +1,15 @@
 
-# output folder
 out = build/bin_${variation}
-
 includedirs = test1 test2
 
 # build all
-
-defines = TEST
-
 build $out/test1/obj(*): auto test1/*.cpp
 	defines += DLL_EXPORT
-build $out/test1.dll | $out/lib(test1): auto $out/test1/obj(*)
+build $out/shlib(test1) | $out/lib(test1): auto $out/test1/obj(*)
 
 build $out/test2/obj(*): auto test2/*.cpp
 	defines += DLL_EXPORT2
-build $out/test2.dll | $out/lib(test2): auto $out/test2/obj(*)
+build $out/shlib(test2) | $out/lib(test2): auto $out/test2/obj(*)
 
 build $out/obj(*): auto *.cpp
 build $out/app(app): auto $out/obj(*) $out/lib(*)


### PR DESCRIPTION
Actually shared libs work more or less the same on all platforms : you have .dll/.so file and .lib/.a. This is why this approach should work just fine.
