### PR TITLE
Improve transforms names

### DIFF
--- a/buildfox.py
+++ b/buildfox.py
@@ -212,8 +212,8 @@ filter toolset: r"gcc|clang"
 	# extensions transformers
 	transformer application: ${param}
 	transformer objects: ${param}.o
-	transformer library: lib${param}.a
-	transformer shared_library: lib${param}.so
+	transformer library: ${path}lib${file}.a
+	transformer shared_library: ${path}lib${file}.so
 
 	# Clang flags
 	# more info here http://clang.llvm.org/docs/CommandGuide/clang.html

--- a/buildfox.py
+++ b/buildfox.py
@@ -69,9 +69,9 @@ filter toolset:msc
 		rspfile_content = $in $libs
 
 	auto r"^(?i).*\.obj$": cxx r"^(?i).*\.(cpp|cxx|cc|c\+\+)$"
-	auto r"^(?i).*\.obj$": cc r"^(?i).*\.(c)$"
-	auto r"^(?i).*\.exe$": link r"^(?i).*\.(obj|lib)$"
-	auto r"^(?i).*\.dll$": link_so r"^(?i).*\.(obj|lib)$"
+	auto r"^(?i).*\.obj$": cc r"^(?i).*\.c$"
+	auto r"^(?i).*\.exe$": link r"^(?i).*\.obj$"
+	auto r"^(?i).*\.dll$": link_so r"^(?i).*\.obj$"
 	auto r"^(?i).*\.lib$": lib r"^(?i).*\.(obj|lib)$"
 
 	# extensions transformers
@@ -203,17 +203,27 @@ filter toolset: r"gcc|clang"
 		command = $cxx -shared -fPIC $ldflags $frameworks $libdirs -o $out $in $libs
 		description = cxx $in
 
-	auto r"^(?i).*\.o$": cxx r"^(?i).*\.(cpp|cxx|cc|c\+\+)$"
-	auto r"^(?i).*\.o$": cc r"^(?i).*\.(c)$"
-	auto r"^(.*\/)?[^.\/]+$": link r"^(?i).*\.(o|a|so)$"
-	auto r"^(?i).*\.so$": link_so r"^(?i).*\.(o|so)$"
-	auto r"^(?i).*\.a$": lib r"^(?i).*\.(o|a)$"
-
-	# extensions transformers
-	transformer application: ${param}
-	transformer objects: ${param}.o
-	transformer library: ${path}lib${file}.a
-	transformer shared_library: ${path}lib${file}.so
+	# extensions transformers and auto
+	filter system: r"^(?i)(?!windows).*$"
+		auto r"^(?i).*\.o$": cxx r"^(?i).*\.(cpp|cxx|cc|c\+\+)$"
+		auto r"^(?i).*\.o$": cc r"^(?i).*\.c$"
+		auto r"^(.*\/)?[^.\/]+$": link r"^(?i).*\.o$"
+		auto r"^(?i).*\.so$": link_so r"^(?i).*\.o$"
+		auto r"^(?i).*\.a$": lib r"^(?i).*\.(o|a)$"
+		transformer application: ${param}
+		transformer objects: ${param}.o
+		transformer library: ${path}lib${file}.a
+		transformer shared_library: ${path}lib${file}.so
+	filter system: r"^(?i)windows$"
+		auto r"^(?i).*\.o$": cxx r"^(?i).*\.(cpp|cxx|cc|c\+\+)$"
+		auto r"^(?i).*\.o$": cc r"^(?i).*\.c$"
+		auto r"^(?i).*\.exe$": link r"^(?i).*\.o$"
+		auto r"^(?i).*\.dll$": link_so r"^(?i).*\.o$"
+		auto r"^(?i).*\.a$": lib r"^(?i).*\.(o|a)$"
+		transformer application: ${param}.exe
+		transformer objects: ${param}.o
+		transformer library: ${path}lib${file}.a
+		transformer shared_library: ${path}lib${file}.dll
 
 	# Clang flags
 	# more info here http://clang.llvm.org/docs/CommandGuide/clang.html

--- a/buildfox.py
+++ b/buildfox.py
@@ -75,11 +75,10 @@ filter toolset:msc
 	auto r"^(?i).*\.lib$": lib r"^(?i).*\.(obj|lib)$"
 
 	# extensions transformers
-	transformer app: ${param}.exe
-	transformer obj: ${param}.obj
-	transformer lib: ${param}.lib
-	transformer shlib: ${param}.dll
-	transformer shlibdep: ${param}.lib
+	transformer application: ${param}.exe
+	transformer objects: ${param}.obj
+	transformer library: ${param}.lib
+	transformer shared_library: ${param}.dll
 
 	# MSC flags
 	# more info here https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
@@ -211,11 +210,10 @@ filter toolset: r"gcc|clang"
 	auto r"^(?i).*\.a$": lib r"^(?i).*\.(o|a)$"
 
 	# extensions transformers
-	transformer app: ${param}
-	transformer obj: ${param}.o
-	transformer lib: lib${param}.a
-	transformer shlib: lib${param}.so
-	transformer shlibdep: lib${param}.so
+	transformer application: ${param}
+	transformer objects: ${param}.o
+	transformer library: lib${param}.a
+	transformer shared_library: lib${param}.so
 
 	# Clang flags
 	# more info here http://clang.llvm.org/docs/CommandGuide/clang.html

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -194,6 +194,8 @@ In some cases we need to slightly transform values by appending or prepending so
 	# will print very doge very wow
 	# transformer works by splitting input line by spaces
 	# replacing items with template and joining them back with spaces
+	# this one is useful for something like defines or lib variables
+	# which need to prepend/append some extra strings to each item
 	print $test
 	
 	transformer img: ${param}.png
@@ -202,6 +204,13 @@ In some cases we need to slightly transform values by appending or prepending so
 	# also transformers are used to modify file names based on environment
 	# note you can only use this form in path
 	build img(name): some_rule some_files
+	
+	# and if you want to add prefix just use transformer like this :
+	transformer img2: ${path}prefix_${file}.png
+	build img2(somepath/somename): some_rule some_files
+	
+	# please note that you cannot use transformer inside a path
+	build somepath/img2(somename): some_rule some_files # invalid
 
 #### Build commands
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -110,7 +110,7 @@ And then to use this library in application we add it to libs and use all libs a
 	
 	build objects(*): auto *.cpp
 	build application(test): auto objects(*) | library(lib/*)
-		libs += library(test)
+		libs += test
 		libdirs += lib
 
 #### Shared libs
@@ -122,7 +122,7 @@ Compiling shared libs is almost the same as static lib, plus you need to add "li
 	
 	build objects(*): auto *.cpp
 	build application(app): auto objects(*) | shared_library(lib/*)
-		libs += library(test1)
+		libs += test1
 		libdirs += lib
 
 If you develop shared libraries for Windows then you also need to mark symbols for export with approach of your choice, one way could be to use [__declspec(dllexport)]( https://msdn.microsoft.com/en-us/library/a90k134d.aspx).

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -39,12 +39,12 @@ You may ask why we need build systems if compiling executables is so easy ? Inde
 So the simplest way to build a simple application with BuildFox is just this :
 
 	# building objects
-	build obj(*): auto *.cpp
+	build objects(*): auto *.cpp
 	
 	# linking executable
-	build app(helloworld): auto obj(*)
+	build application(helloworld): auto objects(*)
 
-First line is compiling object files from .cpp files, and second line is linking final application from object files. ```obj(*)``` is equal to ```*.obj``` on Windows and ```*.o``` on others machines. ```app(helloworld)``` is equal to ```helloworld.exe``` on Windows and ```helloworld``` on others machines. ```auto``` is a name of a rule which will build our output files (object or application) from inputs files (cpp or object) by calling required compiler executables.
+First line is compiling object files from .cpp files, and second line is linking final application from object files. ```objects(*)``` is equal to ```*.obj``` on Windows and ```*.o``` on others machines. ```application(helloworld)``` is equal to ```helloworld.exe``` on Windows and ```helloworld``` on others machines. ```auto``` is a name of a rule which will build our output files (object or application) from inputs files (cpp or object) by calling required compiler executables.
 
 **Please mind that this one is incorrect :**
 
@@ -54,15 +54,15 @@ First line is compiling object files from .cpp files, and second line is linking
 What if we want to compile static library for target "lib" and dynamic library for target "sharedlib" ? Then we use filters :
 
 	# building objects
-	build obj(*): auto *.cpp
+	build objects(*): auto *.cpp
 
 	filter target: lib
 		# linking mylib.lib/.a
-		build lib(mylib): auto obj(*)
+		build library(mylib): auto objects(*)
 
 	filter target: sharedlib
 		# compiling mylib.dll/.so and .lib
-		build shlib(mylib) | lib(mylib): auto obj(*)
+		build shared_library(mylib) | library(mylib): auto objects(*)
 
 Now to set target you just call ```buildfox target=sharedlib```.
 
@@ -76,15 +76,15 @@ BuildFox contains two main parts : execution engine and fox core definitions (th
 
 Usually it's very simple to build console apps :
 
-	build obj(*): auto *.cpp
-	build app(test): auto obj(*)
+	build objects(*): auto *.cpp
+	build application(test): auto objects(*)
 
 If you want to put object files and final executable in other folder, just add it :
 
 	out = build_${variation} # this will form build_debug or build_release
 	
-	build obj($out/*): auto *.cpp
-	build app($out/test): auto obj($out/*)
+	build objects($out/*): auto *.cpp
+	build application($out/test): auto objects($out/*)
 
 In case if you need to specify some compiler flags or defines :
 
@@ -93,33 +93,37 @@ In case if you need to specify some compiler flags or defines :
 	defines = TEST_DEFINE
 	includedirs = some_folder
 	
-	build obj($out/*): auto *.cpp
-	build app($out/test): auto obj($out/*)
+	build objects($out/*): auto *.cpp
+	build application($out/test): auto objects($out/*)
 
 #### Static libs
 
 To build static library we just change target name transform to lib.
 
-	build obj(*): auto *.cpp
-	build lib(test): auto obj(*)
+	build objects(*): auto *.cpp
+	build library(test): auto objects(*)
 
-And then to use this library in application we just add it to inputs
+And then to use this library in application we add it to libs and use all libs as implicit dependency
 
-	build obj(lib/*): auto lib/*.cpp
-	build lib(lib/test): auto obj(lib/*)
+	build objects(lib/*): auto lib/*.cpp
+	build library(lib/test): auto objects(lib/*)
 	
-	build obj(*): auto *.cpp
-	build app(test): auto obj(*) lib(lib/*)
+	build objects(*): auto *.cpp
+	build application(test): auto objects(*) | library(lib/*)
+		libs += library(test)
+		libdirs += lib
 
 #### Shared libs
 
-Compiling shared libs is a bit trickier because of differences between platforms. You need to pass shlib and lib to final library link step. Also to build an app you need to pass library as shlibdep.
+Compiling shared libs is almost the same as static lib, plus you need to add "library" as implicit target because in some cases linking shared library produces static library as well.
 
-	build obj(lib/*): auto lib/*.cpp
-	build shlib(lib/test1) | lib(lib/test1): auto obj(lib/*)
+	build objects(lib/*): auto lib/*.cpp
+	build shared_library(lib/test1) | library(lib/test1): auto objects(lib/*)
 	
-	build obj(*): auto *.cpp
-	build app(app): auto obj(*) shlibdep(lib/*)
+	build objects(*): auto *.cpp
+	build application(app): auto objects(*) | shared_library(lib/*)
+		libs += library(test1)
+		libdirs += lib
 
 If you develop shared libraries for Windows then you also need to mark symbols for export with approach of your choice, one way could be to use [__declspec(dllexport)]( https://msdn.microsoft.com/en-us/library/a90k134d.aspx).
 
@@ -472,11 +476,10 @@ You need to use different file extensions on different platforms, to support thi
 
 Transformer name | Possible Values       | Description
 ---------------- | --------------------- | --------------------------------------------
-app              | .exe or as is         | executable
-obj              | .obj or .o            | object file
-lib              | .lib or .a            | static lib
-shlib            | .dll or .so           | shared lib
-shlibdep         | .lib or .so           | used when you need to link with shared lib
+application      | .exe or as is         | executable
+objects          | .obj or .o            | object file
+library          | .lib or .a            | static lib
+shared_library   | .dll or .so           | shared lib
 
 #### Compiler and linker configuration
 

--- a/examples/console_app/includepath/build.fox
+++ b/examples/console_app/includepath/build.fox
@@ -5,6 +5,6 @@ out = build/bin_${variation}
 includedirs = test1 test2
 
 # build all
-build obj($out/**/*): auto **/*.cpp
-build obj($out/**/*): auto **/*.c
-build app($out/app): auto obj($out/**/*)
+build objects($out/**/*): auto **/*.cpp
+build objects($out/**/*): auto **/*.c
+build application($out/app): auto objects($out/**/*)

--- a/examples/console_app/simple/build.fox
+++ b/examples/console_app/simple/build.fox
@@ -1,6 +1,6 @@
 filter variation:release
 	defines = RELEASE
 
-build obj(*): auto *.cpp
-build obj(*): auto *.c
-build app(test): auto obj(*)
+build objects(*): auto *.cpp
+build objects(*): auto *.c
+build application(test): auto objects(*)

--- a/examples/shared_lib/simple/build.fox
+++ b/examples/shared_lib/simple/build.fox
@@ -1,4 +1,4 @@
 defines = DLL_EXPORT
 
-build obj(*): auto *.cpp
-build shlib(app) | lib(app): auto obj(*)
+build objects(*): auto *.cpp
+build shared_library(app) | library(app): auto objects(*)

--- a/examples/shared_lib/withapp/build.fox
+++ b/examples/shared_lib/withapp/build.fox
@@ -2,13 +2,14 @@ out = build/bin_${variation}
 includedirs = test1 test2
 
 # build all
-build obj($out/test1/*): auto test1/*.cpp
+build objects($out/test1/*): auto test1/*.cpp
 	defines += DLL_EXPORT
-build shlib($out/test1) | lib($out/test1): auto obj($out/test1/*)
+build shared_library($out/test1) | library($out/test1): auto objects($out/test1/*)
 
-build obj($out/test2/*): auto test2/*.cpp
+build objects($out/test2/*): auto test2/*.cpp
 	defines += DLL_EXPORT2
-build shlib($out/test2) | lib($out/test2): auto obj($out/test2/*)
+build shared_library($out/test2) | library($out/test2): auto objects($out/test2/*)
 
-build obj($out/*): auto *.cpp
-build app($out/app): auto obj($out/*) shlibdep($out/*)
+build objects($out/*): auto *.cpp
+build application($out/app): auto objects($out/*)
+	libs += $out/test1 $out/test2

--- a/examples/shared_lib/withapp/build.fox
+++ b/examples/shared_lib/withapp/build.fox
@@ -11,5 +11,5 @@ build objects($out/test2/*): auto test2/*.cpp
 build shared_library($out/test2) | library($out/test2): auto objects($out/test2/*)
 
 build objects($out/*): auto *.cpp
-build application($out/app): auto objects($out/*)
+build application($out/app): auto objects($out/*) | shared_library($out/*)
 	libs += $out/test1 $out/test2

--- a/examples/shared_lib/withapp/build.fox
+++ b/examples/shared_lib/withapp/build.fox
@@ -12,4 +12,5 @@ build shared_library($out/test2) | library($out/test2): auto objects($out/test2/
 
 build objects($out/*): auto *.cpp
 build application($out/app): auto objects($out/*) | shared_library($out/*)
-	libs += $out/test1 $out/test2
+	libs += test1 test2
+	libdirs += $out

--- a/examples/static_lib/simple/build.fox
+++ b/examples/static_lib/simple/build.fox
@@ -1,2 +1,2 @@
-build obj(*): auto *.c
-build lib(app): auto obj(*)
+build objects(*): auto *.c
+build library(app): auto objects(*)

--- a/examples/static_lib/withapp/build.fox
+++ b/examples/static_lib/withapp/build.fox
@@ -13,4 +13,5 @@ build objects($out/test2/*): auto test2/*.cpp
 build library($out/test2): auto objects($out/test2/*)
 
 build objects($out/*): auto *.cpp
-build application($out/app): auto objects($out/*) library($out/*)
+build application($out/app): auto objects($out/*) | library($out/*)
+	libs += $out/test1 $out/test2

--- a/examples/static_lib/withapp/build.fox
+++ b/examples/static_lib/withapp/build.fox
@@ -14,4 +14,5 @@ build library($out/test2): auto objects($out/test2/*)
 
 build objects($out/*): auto *.cpp
 build application($out/app): auto objects($out/*) | library($out/*)
-	libs += $out/test1 $out/test2
+	libs += test1 test2
+	libdirs += $out

--- a/examples/static_lib/withapp/build.fox
+++ b/examples/static_lib/withapp/build.fox
@@ -6,11 +6,11 @@ includedirs = test1 test2
 
 # build all
 
-build obj($out/test1/*): auto test1/*.c
-build lib($out/test1): auto obj($out/test1/*)
+build objects($out/test1/*): auto test1/*.c
+build library($out/test1): auto objects($out/test1/*)
 
-build obj($out/test2/*): auto test2/*.cpp
-build lib($out/test2): auto obj($out/test2/*)
+build objects($out/test2/*): auto test2/*.cpp
+build library($out/test2): auto objects($out/test2/*)
 
-build obj($out/*): auto *.cpp
-build app($out/app): auto obj($out/*) lib($out/*)
+build objects($out/*): auto *.cpp
+build application($out/app): auto objects($out/*) library($out/*)

--- a/lib_engine.py
+++ b/lib_engine.py
@@ -19,7 +19,7 @@ re_var = re.compile("(?<!\$)((?:\$\$)*)\$({)?([a-zA-Z0-9_.-]+)(?(2)})")
 re_alphanumeric = re.compile(r"\W+") # match valid parts of filename
 re_subst = re.compile(r"(?<!\$)(?:\$\$)*\$\{(param|path|file)\}")
 re_non_escaped_space = re.compile(r"(?<!\$)(?:\$\$)* +")
-re_path_transform = re.compile(r"(?<!\$)((?:\$\$)*)([a-zA-Z0-9_.-]+)\((.*?)(?<!\$)(?:\$\$)*\)")
+re_path_transform = re.compile(r"^([a-zA-Z0-9_.-]+)\((.*?)(?<!\$)(?:\$\$)*\)$")
 re_base_escaped = re.compile(r"\$([\| :()])")
 
 class Engine:
@@ -215,10 +215,9 @@ class Engine:
 			if value.startswith("r\""):
 				return value
 			def path_transform(matchobj):
-				prefix = matchobj.group(1)
-				name = matchobj.group(2)
-				value = matchobj.group(3)
-				return prefix + self.eval_transform(name, value, eval = False)
+				name = matchobj.group(1)
+				value = matchobj.group(2)
+				return self.eval_transform(name, value, eval = False)
 			if "(" in value:
 				value = re_path_transform.sub(path_transform, value)
 			return self.eval(value)

--- a/lib_engine.py
+++ b/lib_engine.py
@@ -182,7 +182,7 @@ class Engine:
 			"please check if your file extensions are supported by current toolchain (%s:%i) " +
 			"please also mind that file extensions like object files ('.o' and '.obj') and " + 
 			"executables may differ between platforms, so you should use transforms to make them work, " +
-			"for example 'build obj(*): auto *.cpp' instead of 'build *.obj: auto *.cpp'") % (
+			"for example 'build objects(*): auto *.cpp' instead of 'build *.obj: auto *.cpp'") % (
 			self.current_line,
 			self.filename,
 			self.current_line_i

--- a/lib_selftest.py
+++ b/lib_selftest.py
@@ -6,8 +6,8 @@ import glob
 def selftest_setup():
 	with open("__selftest_build.fox", "w") as f:
 		f.write("""
-build obj(__selftest_src): auto __selftest_src.cpp
-build app(__selftest_app): auto obj(__selftest_src)
+build objects(__selftest_src): auto __selftest_src.cpp
+build application(__selftest_app): auto objects(__selftest_src)
 """)
 
 	with open("__selftest_src.cpp", "w") as f:

--- a/readme.md
+++ b/readme.md
@@ -8,13 +8,13 @@ Minimalistic ninja generator
 
 Build all files in current folder :
 
-	build obj(*): auto *.cpp
-	build app(helloworld): auto obj(*)
+	build objects(*): auto *.cpp
+	build application(helloworld): auto objects(*)
 
 Or build all files recursively :
 
-	build obj(obj/**_*): auto **/*.cpp
-	build app(bin/helloworld): auto obj(obj/*)
+	build objects(obj/**_*): auto **/*.cpp
+	build application(bin/helloworld): auto objects(obj/*)
 
 ### Usage
 


### PR DESCRIPTION
Fix #102 
- Path transforms are only allowed on the start of the path like this `something(path/path/file)`
- app -> application
- obj -> objects
- lib -> library
- shlib -> shared_library
- shlib_dep -> removed, see below

I also removed shlib_dep because shared_library_dependency is just in my way too much. So instead of writing like this :

```
build app(test): obj(obj/*) shlib_dep(libs/*)
```

You should write like this now :

```
# last part after | here means that application will be rebuilt when library changes
build application(test): objects(obj/*) | shared_library(libs/*)
    libs += testlib
    libdirs += libs
```

Pros : no difference between linking with shared or static library (only difference in implicit dependency). Cons : you need to specify all libraries by hand, which somewhat unfriendly.

PS. I honestly prefer shorter names, maybe we should allow both or enable some sort of 1337 syntax :expressionless:
